### PR TITLE
Override `name` field in custom Error classes

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,11 +4,13 @@ import * as Comlink from "comlink";
 export class InterruptError extends Error {
   // To avoid having to use instanceof
   public readonly type = "InterruptError";
+  public readonly name = this.type;
 }
 
 export class NoChannelError extends Error {
   // To avoid having to use instanceof
   public readonly type = "NoChannelError";
+  public readonly name = this.type;
 }
 
 export class SyncClient<T = any> {


### PR DESCRIPTION
Hello, first of all thank you much for your great open-source projects. I am working on a personal project which uses Pyodide and your libraries are truly helpful.

This PR adds overriding of `name` field to custom Error classes - `InterruptError` and `NoChannelError`.

When an error object is thrown from JavaScript to Python, it is converted into `JsException` object and its field values are lost (except for `.name` and `.message`). Therefore from Python side, it is impossible to tell which type of error is thrown.

I thought that replacing `type` field with `name` field is more idiomatic (and maybe this is what you intended originally?), however this would be a breaking change.